### PR TITLE
(CONT-234) Fix failing parameterised command test

### DIFF
--- a/lib/puppet-lint/plugins/check_unsafe_interpolations.rb
+++ b/lib/puppet-lint/plugins/check_unsafe_interpolations.rb
@@ -11,20 +11,51 @@ PuppetLint.new_check(:check_unsafe_interpolations) do
     exec_resources.each do |command_resources|
       # Iterate over each command in execs and check for unsafe interpolations
       command_resources[:tokens].each do |token|
-        # Check if any tokens in command are a varibale
-        if token.type == :VARIABLE
-          warning_message = "unsafe interpolation of variable '#{token.value}' in exec command"
-          notify_warning(token, warning_message)
+        # We are only interested in tokens from command onwards
+        next unless token.type == :NAME
+        # Don't check the command if it is parameterised
+        next if parameterised?(token)
+
+        check_command(token).each do |t|
+          notify_warning(t)
         end
       end
     end
   end
 
   # Raises a warning given a token and message
-  def notify_warning(token, message)
+  def notify_warning(token)
     notify :warning,
-            message: message,
+            message: "unsafe interpolation of variable '#{token.value}' in exec command",
             line: token.line,
             column: token.column
+  end
+
+  # Iterates over the tokens in a command and adds it to an array of violations if it is an input variable
+  def check_command(token)
+    # Initialise variables needed in while loop
+    rule_violations = []
+    current_token = token
+
+    # Iterate through tokens in command
+    while current_token.type != :NEWLINE
+      # Check if token is a varibale and if it is parameterised
+      if current_token.type == :VARIABLE
+        rule_violations.append(current_token)
+      end
+      current_token = current_token.next_token
+    end
+
+    rule_violations
+  end
+
+  # A command is parameterised if its args are placed in an array
+  # This function checks if the current token is a :FARROW and if so, if it is followed by an LBRACK
+  def parameterised?(token)
+    current_token = token
+    while current_token.type != :NEWLINE
+      return true if current_token.type == :FARROW && current_token.next_token.next_token.type == :LBRACK
+      current_token = current_token.next_token
+    end
   end
 end

--- a/spec/puppet-lint/plugins/check_unsafe_interpolations_spec.rb
+++ b/spec/puppet-lint/plugins/check_unsafe_interpolations_spec.rb
@@ -97,13 +97,11 @@ describe 'check_unsafe_interpolations' do
           exec { 'bar':
             command => ['echo', $foo],
           }
-
         }
         PUPPET
       end
 
       it 'detects zero problems' do
-        pending('not implemented yet')
         expect(problems).to have(0).problems
       end
     end


### PR DESCRIPTION
Prior to this commit, the MVP failed a few tests. One such test expects a parameterised command (ie the command parameters are placed in an array) to detect 0 problems. The MVP failed this test as it raised a warning if an input variable was found regardless of the context in which it was found.

This commit fixes this failing test by adding a function which checks if a command is parameterised. This function returns true if an LBRACE is found directly after the FARROW.

This commit also reduces some complexity in how each command is parsed. Previously, there were leading tokens included at the start of each command that were unnecessary to check during iterations. This commit checks for the `command` token and starts a while loop from there to iterate over each token in the command. This makes the logic of the code more straight forward and easier to understand.