### PR TITLE
CONT-234_fix-title-test

### DIFF
--- a/spec/puppet-lint/plugins/check_unsafe_interpolations_spec.rb
+++ b/spec/puppet-lint/plugins/check_unsafe_interpolations_spec.rb
@@ -61,12 +61,10 @@ describe 'check_unsafe_interpolations' do
       end
 
       it 'detects one problem' do
-        pending('not implemented yet')
         expect(problems).to have(1).problems
       end
 
       it 'creates one warning' do
-        pending('not implemented yet')
         expect(problems).to contain_warning(msg)
       end
     end
@@ -96,6 +94,23 @@ describe 'check_unsafe_interpolations' do
 
           exec { 'bar':
             command => ['echo', $foo],
+          }
+        }
+        PUPPET
+      end
+
+      it 'detects zero problems' do
+        expect(problems).to have(0).problems
+      end
+    end
+
+    context 'exec that has an array of args in command' do
+      let(:code) do
+        <<-PUPPET
+        class foo {
+
+          exec { ["foo", "bar", "baz"]:
+            command => echo qux,
           }
         }
         PUPPET


### PR DESCRIPTION
Prior to this commit, the title_tokens function provided by puppet lint was only able to successfully parse titles in single quotes. Titles in double quotes are of interest to us as they may contain unsafe interpolated variables.

This commit adds a modified function for title_tokens called get_title_tokens and checks the result for any interpolated variables.