### PR TITLE
(CONT-234) Refactor nested loops

### DIFF
--- a/lib/puppet-lint/plugins/check_unsafe_interpolations.rb
+++ b/lib/puppet-lint/plugins/check_unsafe_interpolations.rb
@@ -19,16 +19,20 @@ PuppetLint.new_check(:check_unsafe_interpolations) do
 
     # Iterate over each command found in any exec
     exec_resources.each do |command_resources|
-      # Iterate over each command in execs and check for unsafe interpolations
-      command_resources[:tokens].each do |token|
-        # We are only interested in tokens from command onwards
-        next unless token.type == :NAME
-        # Don't check the command if it is parameterised
-        next if parameterised?(token)
+      check_unsafe_interpolations(command_resources)
+    end
+  end
 
-        check_command(token).each do |t|
-          notify_warning(t)
-        end
+  # Iterates over tokens in a command and raises a warning if an interpolated variable is found
+  def check_unsafe_interpolations(command_resources)
+    command_resources[:tokens].each do |token|
+      # We are only interested in tokens from command onwards
+      next unless token.type == :NAME
+      # Don't check the command if it is parameterised
+      next if parameterised?(token)
+
+      check_command(token).each do |t|
+        notify_warning(t)
       end
     end
   end

--- a/spec/puppet-lint/plugins/check_unsafe_interpolations_spec.rb
+++ b/spec/puppet-lint/plugins/check_unsafe_interpolations_spec.rb
@@ -61,12 +61,10 @@ describe 'check_unsafe_interpolations' do
       end
 
       it 'detects one problem' do
-        pending('not implemented yet')
         expect(problems).to have(1).problems
       end
 
       it 'creates one warning' do
-        pending('not implemented yet')
         expect(problems).to contain_warning(msg)
       end
     end
@@ -96,6 +94,23 @@ describe 'check_unsafe_interpolations' do
 
           exec { 'bar':
             command => ['echo', $foo],
+          }
+        }
+        PUPPET
+      end
+
+      it 'detects zero problems' do
+        expect(problems).to have(0).problems
+      end
+    end
+
+    context 'exec that has an array of args in command' do
+      let(:code) do
+        <<-PUPPET
+        class foo {
+
+          exec { ["foo", "bar", "baz"]:
+            command => echo qux,
           }
         }
         PUPPET


### PR DESCRIPTION
The check iterates over an array of exec commands and then over each token in each command. Prior to this commit, these loops were nested. 

The goal of this commit is to refactor this and clean up the code a bit. This was achieved by extracting the logic which iterates over the tokens in a command into a function called check_unsafe_interpolations. Separating code logic into functions and removing nested loops improves code readability and should make it easier to build upon in the future.