### PR TITLE
(CONT-332) Change puppet-lint version dependency

### DIFF
--- a/puppet-lint-check_unsafe_interpolations.gemspec
+++ b/puppet-lint-check_unsafe_interpolations.gemspec
@@ -22,5 +22,5 @@ Gem::Specification.new do |spec|
   spec.license       = 'Apache-2.0'
   spec.required_ruby_version = Gem::Requirement.new(">= 2.7".freeze)
 
-  spec.add_dependency 'puppet-lint', '~> 3.0.0'
+  spec.add_dependency 'puppet-lint', '>= 1.0', '< 4'
 end


### PR DESCRIPTION
Prior to this commit, this plugin require puppet-lint to be v3.0.0. It became apparent when testing the installation of the plugin gem in other modules' Gemfiles that the puppet-lint version is not always >=v3.0.0. This commit changes the version of puppet-lint which this plugin's gem depends to v1.