### PR TITLE
(CONT-333) Ensure get_title_tokens func only gets resource titles

### DIFF
--- a/spec/puppet-lint/plugins/check_unsafe_interpolations_spec.rb
+++ b/spec/puppet-lint/plugins/check_unsafe_interpolations_spec.rb
@@ -160,5 +160,27 @@ describe 'check_unsafe_interpolations' do
         expect(problems).to have(1).problems
       end
     end
+
+    context 'case statement and an exec' do
+      let(:code) do
+        <<-PUPPET
+        class foo {
+          case bar {
+            baz : {
+              echo qux
+            }
+          }
+
+          exec { 'foo':
+            command => "echo bar",
+          }
+        }
+        PUPPET
+      end
+
+      it 'detects zero problems' do
+        expect(problems).to have(0).problems
+      end
+    end
   end
 end


### PR DESCRIPTION
Prior to this commit, the get_title_tokens function searched all tokens to find a :COLON token. It then assumed that the tokens preceding this were the title definition of a resource. This resulted in undesirable behaviour as it would not work if e.g. a case statement was found; no title would be found. Furthermore, titles of known puppet resources is all that this function should be grabbing, instead of anything preceding a :COLON. Therefore, it is a more robust approach to first find a resource definition, like an exec, and then look for a title declaration following this. This is what this commit attempts to achieve.