### PR TITLE
(CONT-333) MVP testing - Lower ruby version

### DIFF
--- a/puppet-lint-check_unsafe_interpolations.gemspec
+++ b/puppet-lint-check_unsafe_interpolations.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
   EOF
   spec.homepage      = 'https://github.com/puppetlabs/puppet-lint-check_unsafe_interpolations'
   spec.license       = 'Apache-2.0'
-  spec.required_ruby_version = Gem::Requirement.new(">= 2.7".freeze)
+  spec.required_ruby_version = Gem::Requirement.new(">= 2.5".freeze)
 
   spec.add_dependency 'puppet-lint', '>= 1.0', '< 4'
 end


### PR DESCRIPTION
Lowering ruby version as this causes errors when bundle installing-ing the gem in puppet modules with ruby v<2.7. Repos seem to be using ruby 2.5.7.