### PR TITLE
(maint) Increase rake boundary

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,7 +10,7 @@ group :development do
   gem 'pry-byebug'
   gem 'pry-stack_explorer'
 
-  gem 'rake', '~> 10.0'
+  gem 'rake', '>= 12.3.3'
   gem 'rspec', '~> 3.1'
   gem 'rspec-collection_matchers', '~> 1.0'
   gem 'rspec-its', '~> 1.0'


### PR DESCRIPTION
Prior to this commit the version of rake has a vulnerability. 

This commit increases the version of rake used to address the vulnerbility in the older version of rake.