### PR TITLE
(CAT-1301) Update puppet-lint dependency to match vox

### DIFF
--- a/puppet-lint-check_unsafe_interpolations.gemspec
+++ b/puppet-lint-check_unsafe_interpolations.gemspec
@@ -22,5 +22,5 @@ Gem::Specification.new do |spec|
   spec.license       = 'Apache-2.0'
   spec.required_ruby_version = Gem::Requirement.new(">= 2.5".freeze)
 
-  spec.add_dependency 'puppet-lint', '>= 1.0', '< 4'
+  spec.add_dependency 'puppet-lint', '~> 4.0'
 end


### PR DESCRIPTION
Prior to this, this plugin's gem would conflict with vox's puppet-lint gem as this plugin depended on an earlier version of puppet-lint. This PR updates this dependency to match vox