### PR TITLE
(CAT-1301) Bump release version

### DIFF
--- a/lib/puppet-lint/plugins/version.rb
+++ b/lib/puppet-lint/plugins/version.rb
@@ -1,4 +1,4 @@
 # version of this gem
 class CheckUnsafeInterpolations
-  VERSION ||= '0.0.4'.freeze
+  VERSION ||= '0.0.5'.freeze
 end


### PR DESCRIPTION
Bumping the version which fixes a dependency issue on puppet-lint which conflicts with vox's puppet-lint plugins gem