### PR TITLE
Fix running the test suite

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,3 +1,4 @@
 require 'puppet-lint'
+require 'rspec/collection_matchers'
 
 PuppetLint::Plugins.load_spec_helper


### PR DESCRIPTION
The rspec-collection_matchers documentation advise to require
rspec-collection_matchers form `spec_helper.rb`.

This fix:

```
Failure/Error: expect(problems).to have(1).problems

NoMethodError:
  undefined method `have' for #<RSpec::ExampleGroups::CheckUnsafeInterpolations::WithFixDisabled::ExecWithUnsafeInterpolationInCommand "detects an unsafe exec command argument" (./spec/puppet-lint/plugins/check_unsafe_interpolations_spec.rb:20)>
```
