### PR TITLE
Fix detection of insecure interpolations in `unless` parameter

### DIFF
--- a/lib/puppet-lint/plugins/check_unsafe_interpolations.rb
+++ b/lib/puppet-lint/plugins/check_unsafe_interpolations.rb
@@ -33,7 +33,7 @@ PuppetLint.new_check(:check_unsafe_interpolations) do
   def check_unsafe_interpolations(command_resources)
     command_resources[:tokens].each do |token|
       # Skip iteration if token isn't a command of type :NAME
-      next unless COMMANDS.include?(token.value) && token.type == :NAME
+      next unless COMMANDS.include?(token.value) && (token.type == :NAME || token.type == :UNLESS)
       # Don't check the command if it is parameterised
       next if parameterised?(token)
 

--- a/spec/puppet-lint/plugins/check_unsafe_interpolations_spec.rb
+++ b/spec/puppet-lint/plugins/check_unsafe_interpolations_spec.rb
@@ -45,7 +45,7 @@ describe 'check_unsafe_interpolations' do
 
       it 'creates two warnings' do
         expect(problems).to contain_warning(msg)
-        expect(problems).to contain_warning(msg)
+        expect(problems).to contain_warning("unsafe interpolation of variable 'bar' in exec command")
       end
     end
 

--- a/spec/puppet-lint/plugins/check_unsafe_interpolations_spec.rb
+++ b/spec/puppet-lint/plugins/check_unsafe_interpolations_spec.rb
@@ -33,6 +33,8 @@ describe 'check_unsafe_interpolations' do
 
           exec { 'bar':
             command => "echo ${foo} ${bar}",
+            onlyif  => "${baz}",
+            unless  => "${bazz}",
           }
 
         }
@@ -40,12 +42,14 @@ describe 'check_unsafe_interpolations' do
       end
 
       it 'detects multiple unsafe exec command arguments' do
-        expect(problems).to have(2).problems
+        expect(problems).to have(4).problems
       end
 
       it 'creates two warnings' do
         expect(problems).to contain_warning(msg)
         expect(problems).to contain_warning("unsafe interpolation of variable 'bar' in exec command")
+        expect(problems).to contain_warning("unsafe interpolation of variable 'baz' in exec command")
+        expect(problems).to contain_warning("unsafe interpolation of variable 'bazz' in exec command")
       end
     end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,3 +1,4 @@
 require 'puppet-lint'
+require 'rspec/collection_matchers'
 
 PuppetLint::Plugins.load_spec_helper


### PR DESCRIPTION
When using the `unless` parameter of an `exec` resource with unsafe string interpolation, the linter should warn about the issue.

It happen that it currently doesn't because unless is also a keyword.

Adjust the linter to cope with this.

Also include:
* #46 