### PR TITLE
Fix safe interpolation detection

### DIFF
--- a/lib/puppet-lint/plugins/check_unsafe_interpolations.rb
+++ b/lib/puppet-lint/plugins/check_unsafe_interpolations.rb
@@ -33,7 +33,7 @@ PuppetLint.new_check(:check_unsafe_interpolations) do
   def check_unsafe_interpolations(command_resources)
     command_resources[:tokens].each do |token|
       # Skip iteration if token isn't a command of type :NAME
-      next unless COMMANDS.include?(token.value) && token.type == :NAME
+      next unless COMMANDS.include?(token.value) && (token.type == :NAME || token.type == :UNLESS)
       # Don't check the command if it is parameterised
       next if parameterised?(token)
 

--- a/spec/puppet-lint/plugins/check_unsafe_interpolations_spec.rb
+++ b/spec/puppet-lint/plugins/check_unsafe_interpolations_spec.rb
@@ -45,7 +45,7 @@ describe 'check_unsafe_interpolations' do
 
       it 'creates two warnings' do
         expect(problems).to contain_warning(msg)
-        expect(problems).to contain_warning(msg)
+        expect(problems).to contain_warning("unsafe interpolation of variable 'bar' in exec command")
       end
     end
 

--- a/spec/puppet-lint/plugins/check_unsafe_interpolations_spec.rb
+++ b/spec/puppet-lint/plugins/check_unsafe_interpolations_spec.rb
@@ -91,6 +91,44 @@ describe 'check_unsafe_interpolations' do
       end
     end
 
+    context 'exec with shell escaped string in command' do
+      let(:code) do
+        <<-PUPPET
+        class foo {
+
+          exec { 'bar':
+            command => "echo ${foo.stdlib::shell_escape} ${bar.stdlib::shell_escape()}",
+            onlyif  => "${bar[1].stdlib::shell_escape}",
+            unless  => "[ -x ${stdlib::shell_escape(reticulate($baz))} ]",
+          }
+        }
+        PUPPET
+      end
+
+      it 'detects zero problems' do
+        expect(problems).to have(0).problems
+      end
+    end
+
+    context 'exec with post-processed shell escaped string in command' do
+      let(:code) do
+        <<-PUPPET
+        class foo {
+
+          exec { 'bar':
+            command => "echo ${reticulate(foo.stdlib::shell_escape)} ${bar.stdlib::shell_escape().reticulate}",
+            onlyif  => "${bar[1].stdlib::shell_escape.reticulate()}",
+            unless  => "[ -x ${reticulate(stdlib::shell_escape($baz))} ]",
+          }
+        }
+        PUPPET
+      end
+
+      it 'detects zero problems' do
+        expect(problems).to have(4).problems
+      end
+    end
+
     context 'exec that has an array of args in command' do
       let(:code) do
         <<-PUPPET

--- a/spec/puppet-lint/plugins/check_unsafe_interpolations_spec.rb
+++ b/spec/puppet-lint/plugins/check_unsafe_interpolations_spec.rb
@@ -33,6 +33,8 @@ describe 'check_unsafe_interpolations' do
 
           exec { 'bar':
             command => "echo ${foo} ${bar}",
+            onlyif  => "${baz}",
+            unless  => "${bazz}",
           }
 
         }
@@ -40,12 +42,14 @@ describe 'check_unsafe_interpolations' do
       end
 
       it 'detects multiple unsafe exec command arguments' do
-        expect(problems).to have(2).problems
+        expect(problems).to have(4).problems
       end
 
       it 'creates two warnings' do
         expect(problems).to contain_warning(msg)
         expect(problems).to contain_warning("unsafe interpolation of variable 'bar' in exec command")
+        expect(problems).to contain_warning("unsafe interpolation of variable 'baz' in exec command")
+        expect(problems).to contain_warning("unsafe interpolation of variable 'bazz' in exec command")
       end
     end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,3 +1,4 @@
 require 'puppet-lint'
+require 'rspec/collection_matchers'
 
 PuppetLint::Plugins.load_spec_helper


### PR DESCRIPTION
Any variable interpolation is currently reported as unsafe.

The stdlib feature a `stdlib::shell_escape()` function (formerly `shell_escape()`) that escape the string passed as parameter.  In such a case, an unsafe interpolation should not be detected.

Add detection of such escaped string and do not report an error in this case.  `stdlib::shell_escape()` must be the last function called in the interpolation for it to not be reported as unsafe.

Fixes #39 

Also include:
* #46
* #47


