### PR TITLE
Update CODEOWNERS to devx

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,2 +1,2 @@
 # added by slack-gitbot
-* @puppetlabs/modules
+* @puppetlabs/devx


### PR DESCRIPTION
Prior to this commit the owners were set to modules, this is a tool therefore setting up owners to be the devx team to ensure we get the correct notifications on the repo.