### PR TITLE
(CAT-1829) - Update ci to run on pull_request_target

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,9 +1,13 @@
 name: "ci"
 
 on:
-  pull_request:
+  push:
     branches:
       - "main"
+  pull_request_target:
+    types:
+      - opened
+      - synchronize
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
(CAT-1829) - Update ci to run on pull_request_target
pdk version: `3.0.1` 
